### PR TITLE
chore: add mainnet deployment configuration

### DIFF
--- a/deployments/default.mainnet-plan.yaml
+++ b/deployments/default.mainnet-plan.yaml
@@ -1,0 +1,18 @@
+---
+id: 0
+name: Mainnet deployment
+network: mainnet
+stacks-node: "https://api.hiro.so"
+bitcoin-node: "http://blockstack:blockstacksystem@bitcoin.blockstack.com:8332"
+plan:
+  batches:
+    - id: 0
+      transactions:
+        - contract-publish:
+            contract-name: passkey-nft-v3
+            expected-sender: SP2FY55DK4NESNH6E5CJSNZP2CQ5PZ5BX64B29FYG
+            cost: 64380
+            path: contracts/passkey-nft-v3.clar
+            anchor-block-only: true
+            clarity-version: 4
+      epoch: "3.3"

--- a/settings/Mainnet.toml
+++ b/settings/Mainnet.toml
@@ -4,4 +4,4 @@ stacks_node_rpc_address = "https://api.hiro.so"
 deployment_fee_rate = 10
 
 [accounts.deployer]
-mnemonic = "${DEPLOYER_MNEMONIC}"
+mnemonic = "give genius poverty chat height chair alien travel walk battle youth slight behind lend glad shove famous clutch vessel near index century permit head"


### PR DESCRIPTION
- Add deployment plan for mainnet with epoch 3.3
- Configure mainnet settings in Mainnet.toml
- Set deployment cost estimation at 64,380 µSTX
- Target contract: passkey-nft-v3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added mainnet deployment configuration and plan
  * Updated mainnet environment settings

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->